### PR TITLE
Use a conda .environment file to easily set up the dev environment and reproduce the behaviour

### DIFF
--- a/.environment
+++ b/.environment
@@ -3,9 +3,12 @@ dependencies:
   - numpy=1.14.1
   - scipy=1.0.0
   - matplotlib=2.1.1
+  - pyzmq=17.0.0
   - jupyter
   - cython
   - pytorch=0.3.1
+  - torchvision=0.2.0
+  - tqdm
   - shogun=6.0.0
   - sphinxcontrib-bibtex
   - sphinx_rtd_theme

--- a/.environment
+++ b/.environment
@@ -2,7 +2,7 @@ dependencies:
   - python=3.5
   - numpy=1.14
   - scipy=1.0
-  - matplotlib=2.1
+  - matplotlib=2.2
   - pyzmq=17.0
   - jupyter=1.0
   - cython=0.28

--- a/.environment
+++ b/.environment
@@ -1,0 +1,12 @@
+dependencies:
+  - python=3.5.3
+  - numpy=1.14.1
+  - scipy=1.0.0
+  - matplotlib=2.1.1
+  - jupyter
+  - cython
+  - pytorch=0.3.1
+  - shogun=6.0.0
+  - sphinxcontrib-bibtex
+  - sphinx_rtd_theme
+  - mock

--- a/.environment
+++ b/.environment
@@ -1,15 +1,16 @@
 dependencies:
   - python=3.5.3
-  - numpy=1.14.1
+  - numpy=1.14.2
   - scipy=1.0.0
   - matplotlib=2.1.1
   - pyzmq=17.0.0
-  - jupyter
-  - cython
-  - pytorch=0.3.1
-  - torchvision=0.2.0
+  - jupyter=1.0.0
+  - cython=0.28
+  - pytorch=0.3.1  # from channel pytorch
+  - torchvision=0.2.0  # from channel pytorch
+  - shogun=6.0.0  # from channel conda-forge
   - tqdm
-  - shogun=6.0.0
+  - pylint
   - sphinxcontrib-bibtex
   - sphinx_rtd_theme
   - mock

--- a/.environment
+++ b/.environment
@@ -1,14 +1,14 @@
 dependencies:
-  - python=3.5.3
-  - numpy=1.14.2
-  - scipy=1.0.0
-  - matplotlib=2.1.1
-  - pyzmq=17.0.0
-  - jupyter=1.0.0
+  - python=3.5
+  - numpy=1.14
+  - scipy=1.0
+  - matplotlib=2.1
+  - pyzmq=17.0
+  - jupyter=1.0
   - cython=0.28
-  - pytorch=0.3.1  # from channel pytorch
-  - torchvision=0.2.0  # from channel pytorch
-  - shogun=6.0.0  # from channel conda-forge
+  - pytorch=0.3  # from channel pytorch
+  - torchvision=0.2  # from channel pytorch
+  - shogun=6.0  # from channel conda-forge
   - tqdm
   - pylint
   - sphinxcontrib-bibtex

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 *.swo
 dist
 docs/_build
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - conda info -a
 
   - conda env create -n test-environment -f .environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda env create -q -n test-environment -f .environment python=$TRAVIS_PYTHON_VERSION
+  - conda env create -n test-environment -f .environment python=$TRAVIS_PYTHON_VERSION
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,13 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  # Add channels necessary for the dependencies
+  - conda config --add channels pytorch
+  - conda config --add channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-  - conda install pytorch -c soumith
-  - conda install -c conda-forge shogun 
-  - conda install numpy
-  - conda install cython
-  - conda install scipy
+  - conda env create -q -n test-environment -f .environment python=$TRAVIS_PYTHON_VERSION
   - python setup.py install
 
 script:

--- a/notebooks/.gitignore
+++ b/notebooks/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints/
+mnist_dir/

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,3 @@
+sphinxcontrib-bibtex
+sphinx_rtd_theme
+mock

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,0 @@
-sphinxcontrib-bibtex
-sphinx_rtd_theme
-mock

--- a/tests/inference_cardinality_test.py
+++ b/tests/inference_cardinality_test.py
@@ -14,7 +14,7 @@ def test_softmax():
             unaries = Variable(torch.randn(batch_size, 15))
             count_potentials = Variable(NINF * torch.ones(batch_size, k + 1))
             count_potentials[:, 1] = 0
-            output_softmax = softmax(unaries)
+            output_softmax = softmax(unaries, dim=1)
             output_cardinf = inference_cardinality(unaries, count_potentials)
             assert np.allclose(output_softmax.cpu().data.numpy(),
                                output_cardinf.cpu().data.numpy())

--- a/torch_two_sample/inference_cardinality.py
+++ b/torch_two_sample/inference_cardinality.py
@@ -139,8 +139,9 @@ def inference_cardinality(node_potentials, cardinality_potential):
 
     bb = bmsgs[:, 2:, :]
     ff = fmsgs[:, :-2, :]
-    b0 = logsumexp(bb + ff, 2)
-    b1 = logsumexp(bb[:, :, :-1] + ff[:, :, 1:], 2) + node_potentials[:, :-1]
+    b0 = logsumexp(bb + ff, 2).view(batch_size, dim_node-1)
+    b1 = logsumexp(bb[:, :, :-1] + ff[:, :, 1:], 2).view(
+        batch_size, dim_node - 1) + node_potentials[:, :-1]
 
     marginals = create_var(0, batch_size, dim_node)
     marginals[:, :-1] = torch.sigmoid(b1 - b0)

--- a/torch_two_sample/inference_cardinality.py
+++ b/torch_two_sample/inference_cardinality.py
@@ -141,7 +141,7 @@ def inference_cardinality(node_potentials, cardinality_potential):
     ff = fmsgs[:, :-2, :]
     b0 = logsumexp(bb + ff, 2).view(batch_size, dim_node-1)
     b1 = logsumexp(bb[:, :, :-1] + ff[:, :, 1:], 2).view(
-        batch_size, dim_node - 1) + node_potentials[:, :-1]
+        batch_size, dim_node-1) + node_potentials[:, :-1]
 
     marginals = create_var(0, batch_size, dim_node)
     marginals[:, :-1] = torch.sigmoid(b1 - b0)

--- a/torch_two_sample/statistics_diff.py
+++ b/torch_two_sample/statistics_diff.py
@@ -244,7 +244,7 @@ class SmoothKNNStatistic(object):
         margs_ = None
         for alpha in alphas:
             if self.k == 1:
-                margs_a = softmax(- alpha * diffs)
+                margs_a = softmax(-alpha * diffs, dim=1)
             else:
                 margs_a = inference_cardinality(
                     - alpha * diffs.cpu(), count_potential)


### PR DESCRIPTION
Fixed some non-backward compatible changes in PyTorch caused by the version change:

- line 143 in `inference_cardinality.py` was adding a `[10, 8, 1]`-sized tensor with a `[10, 8]`-sized tensor.  I assume that somehow this was working in a prior version but not knowing which was that version, I changed it so that it works with PyTorch 0.3.

- it was complaining about deprecating the default `dim` parameter to the `softmax()` function, so I explicitly passed it.

Changed `.travis.yml` to use this `.environment` file when setting up the CI.  Tested it [here](https://travis-ci.org/calincru/torch-two-sample).
