### PR TITLE
Added support for median heuristic for kernel bandwidth of MMD Test

### DIFF
--- a/torch_two_sample/statistics_diff.py
+++ b/torch_two_sample/statistics_diff.py
@@ -352,8 +352,8 @@ class MMDStatistic:
             The first sample, of size ``(n_1, d)``.
         sample_2: variable of shape (n_2, d)
             The second sample, of size ``(n_2, d)``.
-        alphas : list of :class:`float`
-            The kernel parameters.
+        alphas : list of :class:`float` or str 'median'
+            The kernel parameters. If set 'median', then use median heuristic for kernel bandwidth.
         ret_matrix: bool
             If set, the call with also return a second variable.
 
@@ -368,6 +368,10 @@ class MMDStatistic:
             Returned only if ``ret_matrix`` was set to true."""
         sample_12 = torch.cat((sample_1, sample_2), 0)
         distances = pdist(sample_12, sample_12, norm=2)
+        
+        if alphas == 'median':
+            alphas = float(torch.median(distances)) ** 2
+            alphas = [ 1 / alphas ]
 
         kernels = None
         for alpha in alphas:


### PR DESCRIPTION
Hi,

Thanks for maintaining this helpful repo. I would like to add support for median heuristic for kernel bandwidth of MMD Test. Choosing a good kernel bandwidth parameter (sqrt(1/alpha) in the code) for MMD Test can be difficult. One of the most common ways in the literature to choose this bandwidth is using the median heuristic, see Ref [1] and [2], where the bandwidth is chosen to be the median of all pairwise distances. Empirical results show that this heuristic is effective and stable. Would you like to review the code and merge it? Thanks!

Ref [1] Scholkopf, Bernhard and Smola, A. J. ¨ Learning with Kernels. MIT Press, Cambridge, MA, 2002.
Ref [2] Ramdas, Aaditya, et al. "On the decreasing power of kernel and distance based nonparametric hypothesis tests in high dimensions." Proceedings of the AAAI Conference on Artificial Intelligence. Vol. 29. No. 1. 2015.

Regards,
Li